### PR TITLE
Feat: "질문 조회 응답 형태 변경(생성/수정 시간 및 작성자 id 추가)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ FROM amazoncorretto:21
 COPY --from=build /app/build/libs/*.jar /app/question-service.jar
 
 # 앱 실행
-ENTRYPOINT ["java", "-jar", "/app/question-service.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app/question-service.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      TZ: Asia/Seoul
     ports:
       - "${HOST_DB_PORT}:3306"
     volumes:

--- a/src/main/java/com/aoverflow/mmb/question_service/QuestionServiceApplication.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/QuestionServiceApplication.java
@@ -2,12 +2,14 @@ package com.aoverflow.mmb.question_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class QuestionServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(QuestionServiceApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(QuestionServiceApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
@@ -43,7 +43,8 @@ public class QuestionController {
 
   @PutMapping
   public ResponseEntity<QuestionDto> update(@Valid @RequestBody QuestionUpdateDto questionUpdateDto) {
-    return ResponseEntity.ok(questionService.update(questionUpdateDto));
+    questionService.update(questionUpdateDto);
+    return ResponseEntity.ok(questionService.get(questionUpdateDto.getId()));
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreateDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreateDto.java
@@ -1,6 +1,7 @@
 package com.aoverflow.mmb.question_service.question.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,14 +17,18 @@ public class QuestionCreateDto {
   @NotBlank(message = "Content cannot be blank")
   private String content;
 
-  @NotBlank(message = "Author cannot be blank")
-  private String author;
+  @NotNull(message = "Author id cannot be null")
+  private Long authorId;
 
-  public static QuestionCreateDto from(String subject, String content, String author) {
+  @NotBlank(message = "Author name cannot be blank")
+  private String authorName;
+
+  public static QuestionCreateDto from(String subject, String content, Long authorId, String authorName) {
     return QuestionCreateDto.builder()
         .subject(subject)
         .content(content)
-        .author(author)
+        .authorId(authorId)
+        .authorName(authorName)
         .build();
   }
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
@@ -17,7 +17,7 @@ public class QuestionDto {
   private Long id;
   private String subject;
   private String content;
-  private String author;
+  private AuthorDto author;
   private QuestionStatus status;
   private List<AnswerDto> answers;
   private LocalDateTime createdAt;
@@ -29,15 +29,29 @@ public class QuestionDto {
         .map(AnswerDto::from)
         .toList();
 
+    AuthorDto authorDto = AuthorDto.builder()
+        .id(question.getAuthorId())
+        .name(question.getAuthorName())
+        .build();
+
     return QuestionDto.builder()
         .id(question.getId())
         .subject(question.getSubject())
         .content(question.getContent())
-        .author(question.getAuthor())
+        .author(authorDto)
         .status(question.getStatus())
         .answers(answerDtoList)
         .createdAt(question.getCreatedAt())
         .editedAt(question.getEditedAt())
         .build();
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  public static class AuthorDto {
+
+    private Long id;
+    private String name;
   }
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
@@ -3,6 +3,7 @@ package com.aoverflow.mmb.question_service.question.dto;
 import com.aoverflow.mmb.question_service.answer.dto.AnswerDto;
 import com.aoverflow.mmb.question_service.question.entity.Question;
 import com.aoverflow.mmb.question_service.question.entity.QuestionStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,8 @@ public class QuestionDto {
   private String author;
   private QuestionStatus status;
   private List<AnswerDto> answers;
+  private LocalDateTime createdAt;
+  private LocalDateTime editedAt;
 
   public static QuestionDto from(Question question) {
 
@@ -33,6 +36,8 @@ public class QuestionDto {
         .author(question.getAuthor())
         .status(question.getStatus())
         .answers(answerDtoList)
+        .createdAt(question.getCreatedAt())
+        .editedAt(question.getEditedAt())
         .build();
   }
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
@@ -34,7 +34,9 @@ public class Question extends BaseEntity {
 
   private String subject;
   private String content;
-  private String author;
+
+  private Long authorId;
+  private String authorName;
 
   @Enumerated(EnumType.STRING)
   private QuestionStatus status;
@@ -63,18 +65,20 @@ public class Question extends BaseEntity {
   }
 
   @Builder
-  public Question(String subject, String content, String author, QuestionStatus status) {
+  public Question(String subject, String content, Long authorId, String authorName, QuestionStatus status) {
     this.subject = subject;
     this.content = content;
-    this.author = author;
+    this.authorId = authorId;
+    this.authorName = authorName;
     this.status = status;
   }
 
-  public static Question of(String subject, String content, String author, QuestionStatus status) {
+  public static Question of(String subject, String content, Long authorId, String authorName, QuestionStatus status) {
     return Question.builder()
         .subject(subject)
         .content(content)
-        .author(author)
+        .authorId(authorId)
+        .authorName(authorName)
         .status(status)
         .build();
   }
@@ -83,7 +87,8 @@ public class Question extends BaseEntity {
     return Question.builder()
         .subject(questionCreateDto.getSubject())
         .content(questionCreateDto.getContent())
-        .author(questionCreateDto.getAuthor())
+        .authorId(questionCreateDto.getAuthorId())
+        .authorName(questionCreateDto.getAuthorName())
         .status(QuestionStatus.NEW)
         .build();
   }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -58,6 +58,7 @@ public class QuestionService {
         .orElseThrow(EntityNotFoundException::new);
 
     question.update(questionUpdateDto);
+    questionRepository.flush();
 
     return QuestionDto.from(question);
   }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -58,7 +58,6 @@ public class QuestionService {
         .orElseThrow(EntityNotFoundException::new);
 
     question.update(questionUpdateDto);
-    questionRepository.flush();
 
     return QuestionDto.from(question);
   }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
@@ -28,13 +28,14 @@ class QuestionRepositoryTest {
 
   private final static String QUESTION_SUBJECT = "더미 질문 제목";
   private final static String QUESTION_CONTENT = "더미 질문 내용";
-  private final static String QUESTION_AUTHOR = "더미 질문 작성자";
+  private final static Long QUESTION_AUTHOR_ID = 123L;
+  private final static String QUESTION_AUTHOR_NAME = "더미 질문 작성자";
   private final static QuestionStatus QUESTION_STATUS = QuestionStatus.NEW;
 
   @Test
   public void 질문_생성() {
     // given
-    Question question = Question.of("질문 있습니다!", "이게 질문입니다.", "작성자", QuestionStatus.ING);
+    Question question = Question.of("질문 있습니다!", "이게 질문입니다.", 123L, "작성자", QuestionStatus.ING);
 
     // when
     Question savedQuestion = questionRepository.save(question);
@@ -53,7 +54,7 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_제목_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR, QUESTION_STATUS);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME, QUESTION_STATUS);
     Question savedQuestion = questionRepository.save(question);
     String subject = savedQuestion.getSubject();
 
@@ -75,7 +76,7 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_내용_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR, QUESTION_STATUS);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME, QUESTION_STATUS);
     Question savedQuestion = questionRepository.save(question);
     String content = savedQuestion.getContent();
 
@@ -97,7 +98,7 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_상태_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR, QUESTION_STATUS);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME, QUESTION_STATUS);
     Question savedQuestion = questionRepository.save(question);
     QuestionStatus status = savedQuestion.getStatus();
 

--- a/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
@@ -2,6 +2,8 @@ package com.aoverflow.mmb.question_service.question.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.aoverflow.mmb.question_service.config.TestConfig;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
@@ -44,6 +46,8 @@ class QuestionRepositoryTest {
     assertEquals(question.getSubject(), savedQuestion.getSubject());
     assertEquals(question.getContent(), savedQuestion.getContent());
     assertEquals(question.getStatus(), savedQuestion.getStatus());
+    assertNotNull(savedQuestion.getCreatedAt());
+    assertNotNull(savedQuestion.getEditedAt());
   }
 
   @Test
@@ -65,6 +69,7 @@ class QuestionRepositoryTest {
         .orElseThrow(EntityNotFoundException::new);
 
     assertNotEquals(subject, foundQuestion.getSubject());
+    assertTrue(foundQuestion.getEditedAt().isAfter(foundQuestion.getCreatedAt()));
   }
 
   @Test
@@ -86,6 +91,7 @@ class QuestionRepositoryTest {
         .orElseThrow(EntityNotFoundException::new);
 
     assertNotEquals(content, foundQuestion.getContent());
+    assertTrue(foundQuestion.getEditedAt().isAfter(foundQuestion.getCreatedAt()));
   }
 
   @Test
@@ -107,5 +113,6 @@ class QuestionRepositoryTest {
         .orElseThrow(EntityNotFoundException::new);
 
     assertNotEquals(status, foundQuestion.getStatus());
+    assertTrue(foundQuestion.getEditedAt().isAfter(foundQuestion.getCreatedAt()));
   }
 }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -27,7 +27,8 @@ class QuestionServiceTest {
 
   private final static String QUESTION_SUBJECT = "더미 질문 제목";
   private final static String QUESTION_CONTENT = "더미 질문 내용";
-  private final static String QUESTION_AUTHOR = "더미 질문 작성자";
+  private final static Long QUESTION_AUTHOR_ID = 123L;
+  private final static String QUESTION_AUTHOR_NAME = "더미 질문 작성자";
 
   @Test
   @DisplayName("질문 단건 조회")
@@ -36,7 +37,8 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR
+        QUESTION_AUTHOR_ID,
+        QUESTION_AUTHOR_NAME
     );
     QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
 
@@ -57,7 +59,8 @@ class QuestionServiceTest {
       QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
           QUESTION_SUBJECT + i,
           QUESTION_CONTENT + i,
-          QUESTION_AUTHOR + i
+          QUESTION_AUTHOR_ID + i,
+          QUESTION_AUTHOR_NAME + i
       );
       QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
       createdQuestionIds.add(createdQuestionDto.getId());
@@ -80,7 +83,8 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR
+        QUESTION_AUTHOR_ID,
+        QUESTION_AUTHOR_NAME
     );
 
     // when
@@ -98,7 +102,8 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR
+        QUESTION_AUTHOR_ID,
+        QUESTION_AUTHOR_NAME
     );
     QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
 
@@ -128,7 +133,8 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR
+        QUESTION_AUTHOR_ID,
+        QUESTION_AUTHOR_NAME
     );
     QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
 

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -3,6 +3,7 @@ package com.aoverflow.mmb.question_service.question.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.aoverflow.mmb.question_service.question.dto.QuestionCreateDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionDto;
@@ -116,6 +117,8 @@ class QuestionServiceTest {
     assertNotEquals(createdQuestionDto.getSubject(), updatedQuestionDto.getSubject());
     assertNotEquals(createdQuestionDto.getContent(), updatedQuestionDto.getContent());
     assertNotEquals(createdQuestionDto.getStatus(), updatedQuestionDto.getStatus());
+    assertEquals(updatedQuestionDto.getCreatedAt(), createdQuestionDto.getCreatedAt());
+    assertTrue(updatedQuestionDto.getEditedAt().isAfter(createdQuestionDto.getEditedAt()));
   }
 
   @Test


### PR DESCRIPTION
## PR Checklist
- [x] 테스트 코드 추가 여부
- [x] 문서 작성/업데이트 여부 -- [문서 커밋 링크](https://github.com/A-OverFlow/mmb-docs/commit/851677592705e425ecc5382c534c2d2683dc90db)


## PR Type
- [ ] 버그 수정 (Bugfix)
- [x] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [ ] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
#32 

## 설명
* **질문 조회 응답 형태 변경**
  - 생성/수정시간 정보 추가
  - 작성자 id 정보 추가
* **Timezone 관련 설정 추가**
  - Dockerfile 내 `ENTRYPOINT` 명령어 추가
  - docker-compose.yml 내 데이터베이스 environment에 TZ 값 지정

## 기타 전달 사항 (To reviewers)
질문 단건/목록 응답 시 질문 데이터 형태를 다음과 같이 변경했으므로 참고 바랍니다.

**BEFORE:**
```json
{
    "id": 1,
    "subject": "질문입니다.",
    "content": "내용입니다.",
    "author": "heejaykong",
    "status": "NEW",
    "answers": []
}
```

**AFTER:**
```json
{
    "id": 1,
    "subject": "질문입니다.",
    "content": "내용입니다.",
    "author": {
        "id": 123,
        "name": "heejaykong"
    },
    "status": "NEW",
    "answers": [],
    "createdAt": "2025-05-06T23:26:04.436588",
    "editedAt": "2025-05-06T23:26:04.436588"
}
```