### PR TITLE
Feat: "질문서비스 요청/응답 body 형태 변경"

### DIFF
--- a/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package com.aoverflow.mmb.question_service.question.controller;
 
 import com.aoverflow.mmb.question_service.question.dto.QuestionCreateDto;
+import com.aoverflow.mmb.question_service.question.dto.QuestionCustomPageDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
 import com.aoverflow.mmb.question_service.question.service.QuestionService;
@@ -34,7 +35,7 @@ public class QuestionController {
   }
 
   @GetMapping
-  public ResponseEntity<Page<QuestionDto>> getAll(
+  public ResponseEntity<QuestionCustomPageDto<QuestionDto>> getAll(
       @PageableDefault(
           page = 0,
           size = 10,
@@ -42,7 +43,8 @@ public class QuestionController {
           direction = Direction.DESC
       ) Pageable pageable
   ) {
-    return ResponseEntity.ok(questionService.getAll(pageable));
+    Page<QuestionDto> page = questionService.getAll(pageable);
+    return ResponseEntity.ok(QuestionCustomPageDto.from(page));
   }
 
   @PostMapping

--- a/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
@@ -39,7 +39,7 @@ public class QuestionController {
       @PageableDefault(
           page = 0,
           size = 10,
-          sort = {"createdAt", "id"},
+          sort = {"id"},
           direction = Direction.DESC
       ) Pageable pageable
   ) {

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCustomPageDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCustomPageDto.java
@@ -1,0 +1,48 @@
+package com.aoverflow.mmb.question_service.question.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@Setter
+@Builder
+public class QuestionCustomPageDto<T> {
+
+  private List<T> questions; // 필드명 content 대신 questions으로 변경.
+
+  private Pageable pageable;
+
+  private int totalPages;
+  private long totalElements;
+  private boolean last;
+  private int size;
+  private int number;
+
+  private Sort sort;
+
+  private int numberOfElements;
+  private boolean first;
+  private boolean empty;
+
+  public static <T> QuestionCustomPageDto from(Page<T> page) {
+
+    return QuestionCustomPageDto.<T>builder()
+        .questions(page.getContent())
+        .pageable(page.getPageable())
+        .totalPages(page.getTotalPages())
+        .totalElements(page.getTotalElements())
+        .last(page.isLast())
+        .size(page.getSize())
+        .number(page.getNumber())
+        .sort(page.getSort())
+        .numberOfElements(page.getNumberOfElements())
+        .first(page.isFirst())
+        .empty(page.isEmpty())
+        .build();
+  }
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
@@ -1,10 +1,7 @@
 package com.aoverflow.mmb.question_service.question.dto;
 
-import com.aoverflow.mmb.question_service.answer.dto.AnswerDto;
 import com.aoverflow.mmb.question_service.question.entity.Question;
-import com.aoverflow.mmb.question_service.question.entity.QuestionStatus;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,16 +15,10 @@ public class QuestionDto {
   private String subject;
   private String content;
   private AuthorDto author;
-  private QuestionStatus status;
-  private List<AnswerDto> answers;
   private LocalDateTime createdAt;
   private LocalDateTime editedAt;
 
   public static QuestionDto from(Question question) {
-
-    List<AnswerDto> answerDtoList = question.getAnswers().stream()
-        .map(AnswerDto::from)
-        .toList();
 
     AuthorDto authorDto = AuthorDto.builder()
         .id(question.getAuthorId())
@@ -39,8 +30,6 @@ public class QuestionDto {
         .subject(question.getSubject())
         .content(question.getContent())
         .author(authorDto)
-        .status(question.getStatus())
-        .answers(answerDtoList)
         .createdAt(question.getCreatedAt())
         .editedAt(question.getEditedAt())
         .build();

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionUpdateDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionUpdateDto.java
@@ -1,6 +1,5 @@
 package com.aoverflow.mmb.question_service.question.dto;
 
-import com.aoverflow.mmb.question_service.question.entity.QuestionStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -21,15 +20,11 @@ public class QuestionUpdateDto {
   @NotBlank(message = "Content cannot be blank")
   private String content;
 
-  @NotNull(message = "Status cannot be null")
-  private QuestionStatus status;
-
-  public static QuestionUpdateDto from(Long id, String subject, String content, QuestionStatus status) {
+  public static QuestionUpdateDto from(Long id, String subject, String content) {
     return QuestionUpdateDto.builder()
         .id(id)
         .subject(subject)
         .content(content)
-        .status(status)
         .build();
   }
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
@@ -7,8 +7,6 @@ import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,9 +36,6 @@ public class Question extends BaseEntity {
   private Long authorId;
   private String authorName;
 
-  @Enumerated(EnumType.STRING)
-  private QuestionStatus status;
-
   @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Answer> answers = new ArrayList<>();
 
@@ -61,25 +56,22 @@ public class Question extends BaseEntity {
   public void update(QuestionUpdateDto questionUpdateDto) {
     this.subject = questionUpdateDto.getSubject();
     this.content = questionUpdateDto.getContent();
-    this.status = questionUpdateDto.getStatus();
   }
 
   @Builder
-  public Question(String subject, String content, Long authorId, String authorName, QuestionStatus status) {
+  public Question(String subject, String content, Long authorId, String authorName) {
     this.subject = subject;
     this.content = content;
     this.authorId = authorId;
     this.authorName = authorName;
-    this.status = status;
   }
 
-  public static Question of(String subject, String content, Long authorId, String authorName, QuestionStatus status) {
+  public static Question of(String subject, String content, Long authorId, String authorName) {
     return Question.builder()
         .subject(subject)
         .content(content)
         .authorId(authorId)
         .authorName(authorName)
-        .status(status)
         .build();
   }
 
@@ -89,7 +81,6 @@ public class Question extends BaseEntity {
         .content(questionCreateDto.getContent())
         .authorId(questionCreateDto.getAuthorId())
         .authorName(questionCreateDto.getAuthorName())
-        .status(QuestionStatus.NEW)
         .build();
   }
 

--- a/src/main/java/com/aoverflow/mmb/question_service/question/entity/QuestionStatus.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/entity/QuestionStatus.java
@@ -1,5 +1,0 @@
-package com.aoverflow.mmb.question_service.question.entity;
-
-public enum QuestionStatus {
-  NEW, ING, DONE
-}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -56,7 +56,6 @@ public class QuestionService {
         .orElseThrow(EntityNotFoundException::new);
 
     question.update(questionUpdateDto);
-    questionRepository.flush();
 
     return QuestionDto.from(question);
   }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.aoverflow.mmb.question_service.config.TestConfig;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
 import com.aoverflow.mmb.question_service.question.entity.Question;
-import com.aoverflow.mmb.question_service.question.entity.QuestionStatus;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
@@ -30,12 +29,11 @@ class QuestionRepositoryTest {
   private final static String QUESTION_CONTENT = "더미 질문 내용";
   private final static Long QUESTION_AUTHOR_ID = 123L;
   private final static String QUESTION_AUTHOR_NAME = "더미 질문 작성자";
-  private final static QuestionStatus QUESTION_STATUS = QuestionStatus.NEW;
 
   @Test
   public void 질문_생성() {
     // given
-    Question question = Question.of("질문 있습니다!", "이게 질문입니다.", 123L, "작성자", QuestionStatus.ING);
+    Question question = Question.of("질문 있습니다!", "이게 질문입니다.", 123L, "작성자");
 
     // when
     Question savedQuestion = questionRepository.save(question);
@@ -46,7 +44,6 @@ class QuestionRepositoryTest {
 
     assertEquals(question.getSubject(), savedQuestion.getSubject());
     assertEquals(question.getContent(), savedQuestion.getContent());
-    assertEquals(question.getStatus(), savedQuestion.getStatus());
     assertNotNull(savedQuestion.getCreatedAt());
     assertNotNull(savedQuestion.getEditedAt());
   }
@@ -54,12 +51,12 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_제목_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME, QUESTION_STATUS);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME);
     Question savedQuestion = questionRepository.save(question);
     String subject = savedQuestion.getSubject();
 
     // when
-    question.update(QuestionUpdateDto.from(savedQuestion.getId(), "수정한 제목", QUESTION_CONTENT, QUESTION_STATUS));
+    question.update(QuestionUpdateDto.from(savedQuestion.getId(), "수정한 제목", QUESTION_CONTENT));
     questionRepository.save(question);
 
     // then
@@ -76,12 +73,12 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_내용_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME, QUESTION_STATUS);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME);
     Question savedQuestion = questionRepository.save(question);
     String content = savedQuestion.getContent();
 
     // when
-    question.update(QuestionUpdateDto.from(savedQuestion.getId(), QUESTION_SUBJECT, "수정한 내용", QUESTION_STATUS));
+    question.update(QuestionUpdateDto.from(savedQuestion.getId(), QUESTION_SUBJECT, "수정한 내용"));
     questionRepository.save(question);
 
     // then
@@ -98,12 +95,11 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_상태_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME, QUESTION_STATUS);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME);
     Question savedQuestion = questionRepository.save(question);
-    QuestionStatus status = savedQuestion.getStatus();
 
     // when
-    question.update(QuestionUpdateDto.from(savedQuestion.getId(), QUESTION_SUBJECT, QUESTION_CONTENT, QuestionStatus.DONE));
+    question.update(QuestionUpdateDto.from(savedQuestion.getId(), QUESTION_SUBJECT, QUESTION_CONTENT));
     questionRepository.save(question);
 
     // then
@@ -113,7 +109,6 @@ class QuestionRepositoryTest {
     Question foundQuestion = questionRepository.findById(question.getId())
         .orElseThrow(EntityNotFoundException::new);
 
-    assertNotEquals(status, foundQuestion.getStatus());
     assertTrue(foundQuestion.getEditedAt().isAfter(foundQuestion.getCreatedAt()));
   }
 }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.aoverflow.mmb.question_service.question.dto.QuestionCreateDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
-import com.aoverflow.mmb.question_service.question.entity.QuestionStatus;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -128,8 +127,7 @@ class QuestionServiceTest {
     QuestionUpdateDto questionUpdateDto = QuestionUpdateDto.from(
         createdQuestionDto.getId(),
         "수정한 제목",
-        "수정한 내용",
-        QuestionStatus.ING
+        "수정한 내용"
     );
 
     // when
@@ -139,7 +137,6 @@ class QuestionServiceTest {
     assertEquals(createdQuestionDto.getId(), updatedQuestionDto.getId());
     assertNotEquals(createdQuestionDto.getSubject(), updatedQuestionDto.getSubject());
     assertNotEquals(createdQuestionDto.getContent(), updatedQuestionDto.getContent());
-    assertNotEquals(createdQuestionDto.getStatus(), updatedQuestionDto.getStatus());
     assertEquals(updatedQuestionDto.getCreatedAt(), createdQuestionDto.getCreatedAt());
     assertTrue(updatedQuestionDto.getEditedAt().isAfter(createdQuestionDto.getEditedAt()));
   }


### PR DESCRIPTION
## PR Checklist
- [x] 테스트 코드 추가 여부
- [x] 문서 작성/업데이트 여부 -- [문서 커밋 링크](https://github.com/A-OverFlow/mmb-docs/commit/3d03db56739ad0b9dae6eba5f9cdb049017fc639)


## PR Type
- [x] 버그 수정 (Bugfix)
- [x] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [ ] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
#35 

## 설명
질문서비스 요청 또는 응답 body 형태를 다음과 같이 변경합니다.
- 질문 단건 요청/응답 내 "status"(NEW/ING/DONE 나타내는 상태값) key 제거
- 질문 단건 응답 내 "answers"(답변 배열) key 제거
- Pageable 커스터마이징하기(질문 목록 응답 내 "content" -> "questions"로 key 이름 변경)

## 기타 전달 사항 (To reviewers)
N/A