### PR TITLE
Refactor: "작성자 id를 요청 body가 아닌 커스텀 헤더에서 `X-User-Id`로 받도록 리팩토링"

### DIFF
--- a/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -48,8 +49,8 @@ public class QuestionController {
   }
 
   @PostMapping
-  public ResponseEntity<QuestionDto> create(@Valid @RequestBody QuestionCreateDto questionCreateDto) {
-    QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
+  public ResponseEntity<QuestionDto> create(@RequestHeader("X-User-Id") Long authorId, @Valid @RequestBody QuestionCreateDto questionCreateDto) {
+    QuestionDto createdQuestionDto = questionService.create(authorId, questionCreateDto);
     return ResponseEntity.created(URI.create("/questions/" + createdQuestionDto.getId())).body(createdQuestionDto);
   }
 

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreateDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreateDto.java
@@ -1,7 +1,6 @@
 package com.aoverflow.mmb.question_service.question.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,17 +16,13 @@ public class QuestionCreateDto {
   @NotBlank(message = "Content cannot be blank")
   private String content;
 
-  @NotNull(message = "Author id cannot be null")
-  private Long authorId;
-
   @NotBlank(message = "Author name cannot be blank")
   private String authorName;
 
-  public static QuestionCreateDto from(String subject, String content, Long authorId, String authorName) {
+  public static QuestionCreateDto from(String subject, String content, String authorName) {
     return QuestionCreateDto.builder()
         .subject(subject)
         .content(content)
-        .authorId(authorId)
         .authorName(authorName)
         .build();
   }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
@@ -75,11 +75,11 @@ public class Question extends BaseEntity {
         .build();
   }
 
-  public static Question of(QuestionCreateDto questionCreateDto) {
+  public static Question of(Long authorId, QuestionCreateDto questionCreateDto) {
     return Question.builder()
         .subject(questionCreateDto.getSubject())
         .content(questionCreateDto.getContent())
-        .authorId(questionCreateDto.getAuthorId())
+        .authorId(authorId)
         .authorName(questionCreateDto.getAuthorName())
         .build();
   }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -41,8 +41,8 @@ public class QuestionService {
    * 질문 생성
    */
   @Transactional
-  public QuestionDto create(QuestionCreateDto questionCreateDto) {
-    Question savedQuestion = questionRepository.save(Question.of(questionCreateDto));
+  public QuestionDto create(Long authorId, QuestionCreateDto questionCreateDto) {
+    Question savedQuestion = questionRepository.save(Question.of(authorId, questionCreateDto));
 
     return QuestionDto.from(savedQuestion);
   }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -65,6 +65,8 @@ public class QuestionService {
    */
   @Transactional
   public void delete(Long id) {
+    questionRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+
     questionRepository.deleteById(id);
   }
 }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
@@ -91,24 +91,4 @@ class QuestionRepositoryTest {
     assertNotEquals(content, foundQuestion.getContent());
     assertTrue(foundQuestion.getEditedAt().isAfter(foundQuestion.getCreatedAt()));
   }
-
-  @Test
-  public void 질문_상태_수정() {
-    // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME);
-    Question savedQuestion = questionRepository.save(question);
-
-    // when
-    question.update(QuestionUpdateDto.from(savedQuestion.getId(), QUESTION_SUBJECT, QUESTION_CONTENT));
-    questionRepository.save(question);
-
-    // then
-    em.flush();
-    em.clear();
-
-    Question foundQuestion = questionRepository.findById(question.getId())
-        .orElseThrow(EntityNotFoundException::new);
-
-    assertTrue(foundQuestion.getEditedAt().isAfter(foundQuestion.getCreatedAt()));
-  }
 }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -42,10 +42,9 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR_ID,
         QUESTION_AUTHOR_NAME
     );
-    QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
+    QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
 
     // when
     QuestionDto foundQuestion = questionService.get(createdQuestionDto.getId());
@@ -64,10 +63,9 @@ class QuestionServiceTest {
       QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
           QUESTION_SUBJECT + i,
           QUESTION_CONTENT + i,
-          QUESTION_AUTHOR_ID + i,
           QUESTION_AUTHOR_NAME + i
       );
-      QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
+      QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID + i, questionCreateDto);
       createdQuestionIds.add(createdQuestionDto.getId());
     }
 
@@ -100,12 +98,11 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR_ID,
         QUESTION_AUTHOR_NAME
     );
 
     // when
-    QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
+    QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
 
     // then
     QuestionDto foundQuestion = questionService.get(createdQuestionDto.getId());
@@ -119,10 +116,9 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR_ID,
         QUESTION_AUTHOR_NAME
     );
-    QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
+    QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
 
     QuestionUpdateDto questionUpdateDto = QuestionUpdateDto.from(
         createdQuestionDto.getId(),
@@ -148,10 +144,9 @@ class QuestionServiceTest {
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
         QUESTION_CONTENT,
-        QUESTION_AUTHOR_ID,
         QUESTION_AUTHOR_NAME
     );
-    QuestionDto createdQuestionDto = questionService.create(questionCreateDto);
+    QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
 
     // when
     questionService.delete(createdQuestionDto.getId());

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.aoverflow.mmb.question_service.question.dto.QuestionCreateDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,6 +28,9 @@ class QuestionServiceTest {
 
   @Autowired
   QuestionService questionService;
+
+  @Autowired
+  private EntityManager em;
 
   private final static String QUESTION_SUBJECT = "더미 질문 제목";
   private final static String QUESTION_CONTENT = "더미 질문 내용";
@@ -127,14 +131,17 @@ class QuestionServiceTest {
     );
 
     // when
-    QuestionDto updatedQuestionDto = questionService.update(questionUpdateDto);
+    questionService.update(questionUpdateDto);
 
     // then
+    em.flush();
+    em.clear();
+    QuestionDto updatedQuestionDto = questionService.get(questionUpdateDto.getId());
+
     assertEquals(createdQuestionDto.getId(), updatedQuestionDto.getId());
     assertNotEquals(createdQuestionDto.getSubject(), updatedQuestionDto.getSubject());
     assertNotEquals(createdQuestionDto.getContent(), updatedQuestionDto.getContent());
-    assertEquals(updatedQuestionDto.getCreatedAt(), createdQuestionDto.getCreatedAt());
-    assertTrue(updatedQuestionDto.getEditedAt().isAfter(createdQuestionDto.getEditedAt()));
+    assertNotEquals(updatedQuestionDto.getEditedAt(), updatedQuestionDto.getCreatedAt());
   }
 
   @Test

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -154,5 +154,7 @@ class QuestionServiceTest {
     // then
     assertThrows(EntityNotFoundException.class,
         () -> questionService.get(createdQuestionDto.getId()));
+    assertThrows(EntityNotFoundException.class,
+        () -> questionService.delete(createdQuestionDto.getId()));
   }
 }


### PR DESCRIPTION
## PR Checklist
- [x] 테스트 코드 추가 여부
- [x] 문서 작성/업데이트 여부 -- [문서 커밋 링크](https://github.com/A-OverFlow/mmb-docs/commit/949d7660c0ec7e8604a7f5a79d1ece2ac1cfdfaf)


## PR Type
- [x] 버그 수정 (Bugfix)
- [ ] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [ ] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
#37 

## 설명
질문 생성 요청(`POST /questions`) 시, 작성자 id를 body가 아닌 커스텀 헤더에서 `X-User-Id`로 받도록 리팩토링합니다.

## 기타 전달 사항 (To reviewers)
N/A