### PR TITLE
Feat: 질문 생성 시 작성자 이름을 Member 서비스에서 가져오도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,21 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2024.0.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/java/com/aoverflow/mmb/question_service/common/config/OpenFeignConfig.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/common/config/OpenFeignConfig.java
@@ -1,0 +1,10 @@
+package com.aoverflow.mmb.question_service.common.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("com.aoverflow.mmb.question_service")
+public class OpenFeignConfig {
+
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/common/feignClients/MemberServiceClient.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/common/feignClients/MemberServiceClient.java
@@ -1,0 +1,13 @@
+package com.aoverflow.mmb.question_service.common.feignClients;
+
+import com.aoverflow.mmb.question_service.member.dto.MemberDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "member-service", url = "http://mmb-member-service:8082/api/v1")
+public interface MemberServiceClient {
+
+  @GetMapping("/members/me")
+  MemberDto getName(@RequestHeader("X-User-Id") Long authorId);
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/member/dto/MemberDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/member/dto/MemberDto.java
@@ -1,0 +1,15 @@
+package com.aoverflow.mmb.question_service.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MemberDto {
+
+  private String name;
+  private String email;
+  private String picture;
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreateDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreateDto.java
@@ -16,14 +16,10 @@ public class QuestionCreateDto {
   @NotBlank(message = "Content cannot be blank")
   private String content;
 
-  @NotBlank(message = "Author name cannot be blank")
-  private String authorName;
-
-  public static QuestionCreateDto from(String subject, String content, String authorName) {
+  public static QuestionCreateDto from(String subject, String content) {
     return QuestionCreateDto.builder()
         .subject(subject)
         .content(content)
-        .authorName(authorName)
         .build();
   }
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
@@ -75,12 +75,12 @@ public class Question extends BaseEntity {
         .build();
   }
 
-  public static Question of(Long authorId, QuestionCreateDto questionCreateDto) {
+  public static Question of(Long authorId, String authorName, QuestionCreateDto questionCreateDto) {
     return Question.builder()
         .subject(questionCreateDto.getSubject())
         .content(questionCreateDto.getContent())
         .authorId(authorId)
-        .authorName(questionCreateDto.getAuthorName())
+        .authorName(authorName)
         .build();
   }
 

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -1,10 +1,13 @@
 package com.aoverflow.mmb.question_service.question.service;
 
+import com.aoverflow.mmb.question_service.common.feignClients.MemberServiceClient;
+import com.aoverflow.mmb.question_service.member.dto.MemberDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionCreateDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
 import com.aoverflow.mmb.question_service.question.entity.Question;
 import com.aoverflow.mmb.question_service.question.repository.QuestionRepository;
+import feign.FeignException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionService {
 
   private final QuestionRepository questionRepository;
+  private final MemberServiceClient memberServiceClient;
 
   /**
    * 질문 단건 조회
@@ -42,7 +46,14 @@ public class QuestionService {
    */
   @Transactional
   public QuestionDto create(Long authorId, QuestionCreateDto questionCreateDto) {
-    Question savedQuestion = questionRepository.save(Question.of(authorId, questionCreateDto));
+    MemberDto author;
+    try {
+      author = memberServiceClient.getName(authorId);
+    } catch (FeignException.NotFound e) {
+      throw new EntityNotFoundException("작성자를 찾을 수 없음. Id: " + authorId);
+    }
+
+    Question savedQuestion = questionRepository.save(Question.of(authorId, author.getName(), questionCreateDto));
 
     return QuestionDto.from(savedQuestion);
   }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
 
+import com.aoverflow.mmb.question_service.common.feignClients.MemberServiceClient;
+import com.aoverflow.mmb.question_service.member.dto.MemberDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionCreateDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
@@ -20,17 +23,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
 class QuestionServiceTest {
-
-  @Autowired
-  QuestionService questionService;
-
-  @Autowired
-  private EntityManager em;
 
   private final static String QUESTION_SUBJECT = "더미 질문 제목";
   private final static String QUESTION_CONTENT = "더미 질문 내용";
@@ -39,15 +37,44 @@ class QuestionServiceTest {
   private final static int PAGE_NUMBER = 0;
   private final static int PAGE_SIZE = 3;
 
+  @Autowired
+  QuestionService questionService;
+
+  @Autowired
+  private EntityManager em;
+
+  @MockitoBean
+  MemberServiceClient memberServiceClient;
+
+  private void mockAuthorFound() {
+    // mocking FeignClient connection
+    given(memberServiceClient.getName(QUESTION_AUTHOR_ID))
+        .willReturn(MemberDto.builder()
+            .name(QUESTION_AUTHOR_NAME)
+            .build()
+        );
+  }
+
+  private void mockAuthorFound(int i) {
+    // mocking FeignClient connection
+    given(memberServiceClient.getName(QUESTION_AUTHOR_ID + i))
+        .willReturn(MemberDto.builder()
+            .name(QUESTION_AUTHOR_NAME + i)
+            .build()
+        );
+  }
+
   @Test
   @DisplayName("질문 단건 조회")
   void get() {
     // given
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
-        QUESTION_CONTENT,
-        QUESTION_AUTHOR_NAME
+        QUESTION_CONTENT
     );
+
+    mockAuthorFound();
+
     QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
 
     // when
@@ -66,9 +93,9 @@ class QuestionServiceTest {
     for (int i = 0; i < 10; i++) {
       QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
           QUESTION_SUBJECT + i,
-          QUESTION_CONTENT + i,
-          QUESTION_AUTHOR_NAME + i
+          QUESTION_CONTENT + i
       );
+      mockAuthorFound(i);
       QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID + i, questionCreateDto);
       createdQuestionIds.add(createdQuestionDto.getId());
     }
@@ -101,9 +128,10 @@ class QuestionServiceTest {
     // given
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
-        QUESTION_CONTENT,
-        QUESTION_AUTHOR_NAME
+        QUESTION_CONTENT
     );
+
+    mockAuthorFound();
 
     // when
     QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
@@ -119,9 +147,9 @@ class QuestionServiceTest {
     // given
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
-        QUESTION_CONTENT,
-        QUESTION_AUTHOR_NAME
+        QUESTION_CONTENT
     );
+    mockAuthorFound();
     QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
 
     QuestionUpdateDto questionUpdateDto = QuestionUpdateDto.from(
@@ -150,9 +178,9 @@ class QuestionServiceTest {
     // given
     QuestionCreateDto questionCreateDto = QuestionCreateDto.from(
         QUESTION_SUBJECT,
-        QUESTION_CONTENT,
-        QUESTION_AUTHOR_NAME
+        QUESTION_CONTENT
     );
+    mockAuthorFound();
     QuestionDto createdQuestionDto = questionService.create(QUESTION_AUTHOR_ID, questionCreateDto);
 
     // when


### PR DESCRIPTION
## PR Checklist
- [x] 테스트 코드 추가 여부
- [x] 문서 작성/업데이트 여부 -- [문서 커밋 링크](https://github.com/A-OverFlow/mmb-docs/commit/8eaff4ad48c3408a39c5f0dc91e0970a82542e5d)


## PR Type
- [ ] 버그 수정 (Bugfix)
- [x] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [ ] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
#41 

## 설명
질문 생성 시 as-is으로는 요청 body 내에 작성자 이름을 받았다면,
이 PR부터는 작성자 이름을 Question Service가 직접 Member Service에서 가져오므로
요청 body에 작성자 이름을 넣을 필요가 없어집니다.
마이크로서비스 간 통신은 OpenFeign 라이브러리를 활용했습니다.

## 기타 전달 사항 (To reviewers)
N/A