### PR TITLE
Feat: "질문 조회 응답 내 작성자 name을 nickname으로 교체"

### DIFF
--- a/src/main/java/com/aoverflow/mmb/question_service/common/feignClients/MemberServiceClient.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/common/feignClients/MemberServiceClient.java
@@ -9,5 +9,5 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface MemberServiceClient {
 
   @GetMapping("/members/me")
-  MemberDto getName(@RequestHeader("X-User-Id") Long authorId);
+  MemberDto getMember(@RequestHeader("X-User-Id") Long authorId);
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/member/dto/MemberDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/member/dto/MemberDto.java
@@ -9,7 +9,9 @@ import lombok.Setter;
 @Builder
 public class MemberDto {
 
+  private Long id;
   private String name;
   private String email;
+  private String nickname;
   private String picture;
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionDto.java
@@ -22,7 +22,7 @@ public class QuestionDto {
 
     AuthorDto authorDto = AuthorDto.builder()
         .id(question.getAuthorId())
-        .name(question.getAuthorName())
+        .nickname(question.getAuthorNickname())
         .build();
 
     return QuestionDto.builder()
@@ -41,6 +41,6 @@ public class QuestionDto {
   public static class AuthorDto {
 
     private Long id;
-    private String name;
+    private String nickname;
   }
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/entity/Question.java
@@ -34,7 +34,7 @@ public class Question extends BaseEntity {
   private String content;
 
   private Long authorId;
-  private String authorName;
+  private String authorNickname;
 
   @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Answer> answers = new ArrayList<>();
@@ -59,28 +59,28 @@ public class Question extends BaseEntity {
   }
 
   @Builder
-  public Question(String subject, String content, Long authorId, String authorName) {
+  public Question(String subject, String content, Long authorId, String authorNickname) {
     this.subject = subject;
     this.content = content;
     this.authorId = authorId;
-    this.authorName = authorName;
+    this.authorNickname = authorNickname;
   }
 
-  public static Question of(String subject, String content, Long authorId, String authorName) {
+  public static Question of(String subject, String content, Long authorId, String authorNickname) {
     return Question.builder()
         .subject(subject)
         .content(content)
         .authorId(authorId)
-        .authorName(authorName)
+        .authorNickname(authorNickname)
         .build();
   }
 
-  public static Question of(Long authorId, String authorName, QuestionCreateDto questionCreateDto) {
+  public static Question of(Long authorId, String authorNickname, QuestionCreateDto questionCreateDto) {
     return Question.builder()
         .subject(questionCreateDto.getSubject())
         .content(questionCreateDto.getContent())
         .authorId(authorId)
-        .authorName(authorName)
+        .authorNickname(authorNickname)
         .build();
   }
 

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -48,12 +48,12 @@ public class QuestionService {
   public QuestionDto create(Long authorId, QuestionCreateDto questionCreateDto) {
     MemberDto author;
     try {
-      author = memberServiceClient.getName(authorId);
+      author = memberServiceClient.getMember(authorId);
     } catch (FeignException.NotFound e) {
       throw new EntityNotFoundException("작성자를 찾을 수 없음. Id: " + authorId);
     }
 
-    Question savedQuestion = questionRepository.save(Question.of(authorId, author.getName(), questionCreateDto));
+    Question savedQuestion = questionRepository.save(Question.of(authorId, author.getNickname(), questionCreateDto));
 
     return QuestionDto.from(savedQuestion);
   }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
@@ -28,7 +28,7 @@ class QuestionRepositoryTest {
   private final static String QUESTION_SUBJECT = "더미 질문 제목";
   private final static String QUESTION_CONTENT = "더미 질문 내용";
   private final static Long QUESTION_AUTHOR_ID = 123L;
-  private final static String QUESTION_AUTHOR_NAME = "더미 질문 작성자";
+  private final static String QUESTION_AUTHOR_NICKNAME = "더미 질문 작성자";
 
   @Test
   public void 질문_생성() {
@@ -51,7 +51,7 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_제목_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NICKNAME);
     Question savedQuestion = questionRepository.save(question);
     String subject = savedQuestion.getSubject();
 
@@ -73,7 +73,7 @@ class QuestionRepositoryTest {
   @Test
   public void 질문_내용_수정() {
     // given
-    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NAME);
+    Question question = Question.of(QUESTION_SUBJECT, QUESTION_CONTENT, QUESTION_AUTHOR_ID, QUESTION_AUTHOR_NICKNAME);
     Question savedQuestion = questionRepository.save(question);
     String content = savedQuestion.getContent();
 

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -48,7 +48,7 @@ class QuestionServiceTest {
 
   private void mockAuthorFound() {
     // mocking FeignClient connection
-    given(memberServiceClient.getName(QUESTION_AUTHOR_ID))
+    given(memberServiceClient.getMember(QUESTION_AUTHOR_ID))
         .willReturn(MemberDto.builder()
             .name(QUESTION_AUTHOR_NAME)
             .build()
@@ -57,7 +57,7 @@ class QuestionServiceTest {
 
   private void mockAuthorFound(int i) {
     // mocking FeignClient connection
-    given(memberServiceClient.getName(QUESTION_AUTHOR_ID + i))
+    given(memberServiceClient.getMember(QUESTION_AUTHOR_ID + i))
         .willReturn(MemberDto.builder()
             .name(QUESTION_AUTHOR_NAME + i)
             .build()


### PR DESCRIPTION
## PR Checklist
- [x] 테스트 코드 추가 여부
- [x] 문서 작성/업데이트 여부 -- [문서 커밋 링크](https://github.com/A-OverFlow/mmb-docs/commit/1c90e6fcd99f7333f3f8796a224d9d1114f09903)


## PR Type
- [ ] 버그 수정 (Bugfix)
- [x] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [ ] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
#45 

## 설명
질문 조회 시 as-is는 응답 body 내에 작성자 이름을 name으로 줬다면,
이 PR부터는 작성자 이름을 name이 아닌 nickname으로 줍니다. (멤버 도메인 상 name과 nickname은 다른 데이터임)

## 기타 전달 사항 (To reviewers)
N/A