### PR TITLE
Feat: "질문 목록 조회 시 작성자 id 필터 구현"

### DIFF
--- a/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/controller/QuestionController.java
@@ -35,9 +35,10 @@ public class QuestionController {
   @GetMapping
   public ResponseEntity<QuestionPageDto<QuestionDto>> getPaginatedList(
       @RequestParam(required = false) Long lastId,
-      @RequestParam(defaultValue = "10") int size
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(required = false) Long authorId
   ) {
-    return ResponseEntity.ok(questionService.getPaginatedList(lastId, size));
+    return ResponseEntity.ok(questionService.getPaginatedList(lastId, size, authorId));
   }
 
   @PostMapping

--- a/src/main/java/com/aoverflow/mmb/question_service/question/repository/QuestionCustomRepository.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/repository/QuestionCustomRepository.java
@@ -5,11 +5,13 @@ import java.util.List;
 
 public interface QuestionCustomRepository {
 
-  List<Question> findAfterIdOrderByIdDesc(Long id, int size);
+  List<Question> findByPageAndFiltersOrderByIdDesc(Long id, int size, Long authorId);
 
   List<Question> findByAnswerAuthor(String author);
 
   List<Question> findByAnswerContent(String content);
 
   List<Question> findByHashtagName(String name);
+
+  Long countByAuthorId(Long authorId);
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/repository/QuestionCustomRepositoryImpl.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/repository/QuestionCustomRepositoryImpl.java
@@ -17,11 +17,15 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public List<Question> findAfterIdOrderByIdDesc(Long id, int size) {
+  public List<Question> findByPageAndFiltersOrderByIdDesc(Long id, int size, Long authorId) {
     BooleanBuilder builder = new BooleanBuilder();
 
     if (id != null) {
       builder.and(question.id.lt(id));
+    }
+
+    if (authorId != null) {
+      builder.and(question.authorId.eq(authorId));
     }
 
     return queryFactory
@@ -66,5 +70,20 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
         .on(questionHashtag.hashtag.eq(hashtag))
         .where(hashtag.name.eq(name))
         .fetch();
+  }
+
+  @Override
+  public Long countByAuthorId(Long authorId) {
+    BooleanBuilder builder = new BooleanBuilder();
+
+    if (authorId != null) {
+      builder.and(question.authorId.eq(authorId));
+    }
+
+    return queryFactory
+        .select(question.count())
+        .from(question)
+        .where(builder)
+        .fetchOne();
   }
 }

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -39,10 +39,10 @@ public class QuestionService {
   /**
    * 질문 목록 조회
    */
-  public QuestionPageDto<QuestionDto> getPaginatedList(Long id, int size) {
+  public QuestionPageDto<QuestionDto> getPaginatedList(Long id, int size, Long authorId) {
     int validSize = (size <= 0) ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
 
-    List<Question> questions = questionRepository.findAfterIdOrderByIdDesc(id, validSize + 1);  // hasNext 판단을 위해 +1 하기.
+    List<Question> questions = questionRepository.findByPageAndFiltersOrderByIdDesc(id, validSize + 1, authorId);  // hasNext 판단을 위해 validSize + 1 하기.
 
     boolean hasNext = questions.size() > validSize;
     if (hasNext) {
@@ -58,7 +58,7 @@ public class QuestionService {
       lastId = questions.getLast().getId();
     }
 
-    Long totalElements = questionRepository.count();
+    Long totalElements = questionRepository.countByAuthorId(authorId);
 
     return QuestionPageDto.<QuestionDto>builder()
         .questions(questionDtoList)

--- a/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/repository/QuestionRepositoryTest.java
@@ -6,10 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.aoverflow.mmb.question_service.config.TestConfig;
+import com.aoverflow.mmb.question_service.member.dto.MemberDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
 import com.aoverflow.mmb.question_service.question.entity.Question;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -27,8 +29,78 @@ class QuestionRepositoryTest {
 
   private final static String QUESTION_SUBJECT = "더미 질문 제목";
   private final static String QUESTION_CONTENT = "더미 질문 내용";
-  private final static Long QUESTION_AUTHOR_ID = 123L;
+  private final static Long QUESTION_AUTHOR_ID = 1L;
   private final static String QUESTION_AUTHOR_NICKNAME = "더미 질문 작성자";
+
+  private void saveList() {
+    questionRepository.deleteAll();
+
+    MemberDto member1 = MemberDto.builder()
+        .id(QUESTION_AUTHOR_ID)
+        .nickname("영희")
+        .build();
+    MemberDto member2 = MemberDto.builder()
+        .id(2L)
+        .nickname("미애")
+        .build();
+
+    // member1: 5개 질문
+    for (int i = 1; i <= 5; i++) {
+      questionRepository.save(Question.of(
+          QUESTION_SUBJECT + i,
+          QUESTION_CONTENT + i,
+          member1.getId(),
+          member1.getNickname())
+      );
+    }
+    // member2: 3개 질문
+    for (int i = 6; i <= 8; i++) {
+      questionRepository.save(Question.of(
+          QUESTION_SUBJECT + i,
+          QUESTION_CONTENT + i,
+          member2.getId(),
+          member2.getNickname())
+      );
+    }
+  }
+
+  @Test
+  public void 질문_목록_조회__첫_페이지는_가장_최신_목록을_조회한다() {
+    // given
+    saveList();
+
+    // when
+    List<Question> questions = questionRepository.findByPageAndFiltersOrderByIdDesc(null, 5, null);
+
+    // then
+    assertEquals(5, questions.size());
+    assertEquals(questions.getFirst().getId(), 8); // 가장 최신 id
+  }
+
+  @Test
+  public void 질문_목록_조회__lastId가_주어지면_그보다_이전의_목록을_조회한다() {
+    // given
+    saveList();
+
+    // when
+    List<Question> questions = questionRepository.findByPageAndFiltersOrderByIdDesc(6L, 5, null);
+
+    // then
+    assertTrue(questions.stream().allMatch(question -> question.getId() < 6));
+  }
+
+  @Test
+  public void 질문_목록_조회__authorId가_주어지면_그_작성자의_질문만_조회한다() {
+    // given
+    saveList();
+
+    // when
+    List<Question> questions = questionRepository.findByPageAndFiltersOrderByIdDesc(null, 10, QUESTION_AUTHOR_ID);
+
+    // then
+    assertEquals(5, questions.size());
+    assertTrue(questions.stream().allMatch(question -> question.getAuthorId().equals(QUESTION_AUTHOR_ID)));
+  }
 
   @Test
   public void 질문_생성() {
@@ -90,5 +162,21 @@ class QuestionRepositoryTest {
 
     assertNotEquals(content, foundQuestion.getContent());
     assertTrue(foundQuestion.getEditedAt().isAfter(foundQuestion.getCreatedAt()));
+  }
+
+  @Test
+  public void 질문_개수_조회() {
+    // given
+    saveList();
+
+    // when
+    Long countMember1 = questionRepository.countByAuthorId(QUESTION_AUTHOR_ID);
+    Long countMember2 = questionRepository.countByAuthorId(2L);
+    Long countAll = questionRepository.countByAuthorId(null);
+
+    // then
+    assertEquals(5, countMember1);
+    assertEquals(3, countMember2);
+    assertEquals(8, countAll);
   }
 }

--- a/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/aoverflow/mmb/question_service/question/service/QuestionServiceTest.java
@@ -102,9 +102,9 @@ class QuestionServiceTest {
     }
 
     // when
-    QuestionPageDto<QuestionDto> page = questionService.getPaginatedList(null, PAGE_SIZE);
-    QuestionPageDto<QuestionDto> wrongRequestPage1 = questionService.getPaginatedList(null, NEGATIVE_PAGE_SIZE);
-    QuestionPageDto<QuestionDto> wrongRequestPage2 = questionService.getPaginatedList(null, ABUSIVE_PAGE_SIZE);
+    QuestionPageDto<QuestionDto> page = questionService.getPaginatedList(null, PAGE_SIZE, null);
+    QuestionPageDto<QuestionDto> wrongRequestPage1 = questionService.getPaginatedList(null, NEGATIVE_PAGE_SIZE, null);
+    QuestionPageDto<QuestionDto> wrongRequestPage2 = questionService.getPaginatedList(null, ABUSIVE_PAGE_SIZE, null);
 
     // then
     List<QuestionDto> content = page.getQuestions();    // 조회된 데이터


### PR DESCRIPTION
## PR Checklist
- [x] 테스트 코드 추가 여부
- [x] 문서 작성/업데이트 여부 -- [문서 항목 링크](https://github.com/A-OverFlow/mmb-docs/blob/main/0_%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8_%EA%B4%80%EB%A6%AC/1_%EA%B0%9C%EB%B0%9C/API_Docs/QUESTION_REST_API_Docs.md#2113-params)

## PR Type
- [ ] 버그 수정 (Bugfix)
- [x] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [ ] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
#40 

## 설명
질문 목록 조회 시 as-is로서는 작성자 기준으로 필터링할 수 없었다면
이 PR부터는 질문 목록 조회 시 `authorId`를 쿼리 파라미터로 요청할 수 있습니다.

## 기타 전달 사항 (To reviewers)
N/A