### PR TITLE
Feat: "Transactional Outbox 패턴 실습"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,14 @@ services:
       - external-net
     depends_on:
       - db
+      - kafka
     restart: always
     logging:
-        driver: fluentd
-        options:
-            fluentd-address: localhost:24224
-            tag: mmb-question-service
+      driver: fluentd
+      options:
+        fluentd-address: localhost:24224
+        tag: mmb-question-service
+
   # db 컨테이너만 실행 : docker compose up -d db
   db:
     image: mysql:8
@@ -31,6 +33,32 @@ services:
       - "${HOST_DB_PORT}:3306"
     volumes:
       - mysql_data:/var/lib/mysql
+    networks:
+      - external-net
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - external-net
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     networks:
       - external-net
 

--- a/src/main/java/com/aoverflow/mmb/question_service/QuestionServiceApplication.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/QuestionServiceApplication.java
@@ -3,8 +3,10 @@ package com.aoverflow.mmb.question_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class QuestionServiceApplication {
 

--- a/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreatedEvent.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/dto/QuestionCreatedEvent.java
@@ -1,0 +1,15 @@
+package com.aoverflow.mmb.question_service.question.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class QuestionCreatedEvent {
+
+  private Long questionId;
+  private Long authorId;
+  private String subject;
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/entity/MessageOutbox.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/entity/MessageOutbox.java
@@ -1,0 +1,54 @@
+package com.aoverflow.mmb.question_service.question.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MessageOutbox {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "message_outbox_id")
+  private Long id;
+
+  private String topic;
+
+  @Lob
+  private String payload;
+
+  private boolean sent = false;
+
+  private LocalDateTime createdAt = LocalDateTime.now();
+
+  @Builder
+  public MessageOutbox(String topic, String payload, boolean sent, LocalDateTime createdAt) {
+    this.topic = topic;
+    this.payload = payload;
+    this.sent = sent;
+    this.createdAt = createdAt;
+  }
+
+  public static MessageOutbox of(String topic, String payload, boolean sent, LocalDateTime createdAt) {
+    return MessageOutbox.builder()
+        .topic(topic)
+        .payload(payload)
+        .sent(sent)
+        .createdAt(createdAt)
+        .build();
+  }
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/repository/MessageOutboxCustomRepository.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/repository/MessageOutboxCustomRepository.java
@@ -1,0 +1,9 @@
+package com.aoverflow.mmb.question_service.question.repository;
+
+import com.aoverflow.mmb.question_service.question.entity.MessageOutbox;
+import java.util.List;
+
+public interface MessageOutboxCustomRepository {
+
+  List<MessageOutbox> findUnsentMessages();
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/repository/MessageOutboxCustomRepositoryImpl.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/repository/MessageOutboxCustomRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.aoverflow.mmb.question_service.question.repository;
+
+import static com.aoverflow.mmb.question_service.question.entity.QMessageOutbox.messageOutbox;
+
+import com.aoverflow.mmb.question_service.question.entity.MessageOutbox;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MessageOutboxCustomRepositoryImpl implements MessageOutboxCustomRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<MessageOutbox> findUnsentMessages() {
+    return queryFactory
+        .selectFrom(messageOutbox)
+        .where(messageOutbox.sent.eq(false))
+        .orderBy(messageOutbox.createdAt.asc())
+        .fetch();
+  }
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/repository/MessageOutboxRepository.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/repository/MessageOutboxRepository.java
@@ -1,0 +1,8 @@
+package com.aoverflow.mmb.question_service.question.repository;
+
+import com.aoverflow.mmb.question_service.question.entity.MessageOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageOutboxRepository extends JpaRepository<MessageOutbox, Long>, MessageOutboxCustomRepository {
+
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/MessagePublishingJob.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/MessagePublishingJob.java
@@ -1,0 +1,32 @@
+package com.aoverflow.mmb.question_service.question.service;
+
+import com.aoverflow.mmb.question_service.question.entity.MessageOutbox;
+import com.aoverflow.mmb.question_service.question.repository.MessageOutboxRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessagePublishingJob {
+
+  private final MessageOutboxRepository messageOutboxRepository;
+  private final KafkaTemplate<String, String> kafkaTemplate;
+
+  @Scheduled(fixedDelay = 5000)
+  public void publishMessages() {
+    List<MessageOutbox> unsentMessages = messageOutboxRepository.findUnsentMessages();
+    for (MessageOutbox message : unsentMessages) {
+      try {
+        kafkaTemplate.send(message.getTopic(), message.getPayload());
+        message.setSent(true);
+        messageOutboxRepository.save(message);
+        System.out.println("✅ Kafka 메시지 발행됨: " + message.getTopic());
+      } catch (Exception e) {
+        System.err.println("❌ Kafka 메시지 발행 실패: " + e.getMessage());
+      }
+    }
+  }
+}

--- a/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
+++ b/src/main/java/com/aoverflow/mmb/question_service/question/service/QuestionService.java
@@ -4,11 +4,16 @@ import com.aoverflow.mmb.question_service.common.feignClients.MemberServiceClien
 import com.aoverflow.mmb.question_service.member.dto.MemberDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionCountDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionCreateDto;
+import com.aoverflow.mmb.question_service.question.dto.QuestionCreatedEvent;
 import com.aoverflow.mmb.question_service.question.dto.QuestionDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionPageDto;
 import com.aoverflow.mmb.question_service.question.dto.QuestionUpdateDto;
+import com.aoverflow.mmb.question_service.question.entity.MessageOutbox;
 import com.aoverflow.mmb.question_service.question.entity.Question;
+import com.aoverflow.mmb.question_service.question.repository.MessageOutboxRepository;
 import com.aoverflow.mmb.question_service.question.repository.QuestionRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
@@ -22,10 +27,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionService {
 
   private final QuestionRepository questionRepository;
+  private final MessageOutboxRepository messageOutboxRepository;
   private final MemberServiceClient memberServiceClient;
+  private final ObjectMapper objectMapper;
 
   private static final int DEFAULT_PAGE_SIZE = 10;
   private static final int MAX_PAGE_SIZE = 1000;
+
+  private static final String TOPIC = "question.created";
 
   /**
    * 질문 단건 조회
@@ -83,6 +92,22 @@ public class QuestionService {
     }
 
     Question savedQuestion = questionRepository.save(Question.of(authorId, author.getNickname(), author.getPicture(), questionCreateDto));
+
+    QuestionCreatedEvent event = QuestionCreatedEvent.builder()
+        .questionId(savedQuestion.getId())
+        .authorId(savedQuestion.getAuthorId())
+        .subject(savedQuestion.getSubject())
+        .build();
+    try {
+      String payload = objectMapper.writeValueAsString(event);
+      MessageOutbox message = MessageOutbox.builder()
+          .topic(TOPIC)
+          .payload(payload)
+          .build();
+      messageOutboxRepository.save(message);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
 
     return QuestionDto.from(savedQuestion);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,16 @@ spring:
         # 사용할 데이터베이스 방언 설정 (MariaDB용)
         dialect: org.hibernate.dialect.MariaDBDialect
 
+  kafka:
+    bootstrap-servers: kafka:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: mmb-question-service
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
 # 로깅 레벨 설정
 logging:
   pattern:


### PR DESCRIPTION
## PR Checklist
- [ ] 테스트 코드 추가 여부
- [x] 문서 작성/업데이트 여부 -- [분산_트랜잭션.md](https://github.com/A-OverFlow/mmb-docs/blob/main/2_%EB%B9%84%EC%A7%80%EB%8B%88%EC%8A%A4%EB%A1%9C%EC%A7%81_%ED%8C%8C%ED%8A%B8/%EA%B3%B5%ED%9D%AC%EC%9E%AC/%EB%B6%84%EC%82%B0_%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98.md)

## PR Type
- [ ] 버그 수정 (Bugfix)
- [x] 기능 (Feature)
- [ ] 코드 포맷팅 (Code style update)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 배포 관련 수정 (Release)
- [x] CI/CD related changes
- [ ] 문서 수정
- [ ] 구조 변경 (application / infrastructure changes)


## 이슈 번호 
#59

## 설명
- 조사한 [분산_트랜잭션.md](https://github.com/A-OverFlow/mmb-docs/blob/main/2_%EB%B9%84%EC%A7%80%EB%8B%88%EC%8A%A4%EB%A1%9C%EC%A7%81_%ED%8C%8C%ED%8A%B8/%EA%B3%B5%ED%9D%AC%EC%9E%AC/%EB%B6%84%EC%82%B0_%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98.md) 문서를 바탕으로 Transactional Outbox 패턴 실습을 질문서비스에 아주 간단하게 적용해 보았습니다. (사용자가 질문 등록 시, Kafka로 질문 등록 이벤트를 outbox에 저장 후 스케줄러로 발행)
  - ![image](https://github.com/user-attachments/assets/20d8c87e-9a6c-44ea-82f3-7e02271cc255)

## 기타 전달 사항 (To reviewers)
N/A